### PR TITLE
Make `--target-kubeconfig` flag optional

### DIFF
--- a/main.go
+++ b/main.go
@@ -80,8 +80,8 @@ func run() error {
 	zapOpts.BindFlags(flag.CommandLine)
 	flag.Parse()
 
-	if opts.kcpkubeconfig == "" || opts.targetkubeconfig == "" {
-		return errors.New("both --kcp-kubeconfig and --target-kubeconfig must be specified")
+	if opts.kcpkubeconfig == "" {
+		return errors.New("--kcp-kubeconfig must be specified")
 	}
 
 	logger := kubezap.New(kubezap.UseFlagOptions(&zapOpts))


### PR DESCRIPTION
Target kubeconfig is not needed in the case the controller is running in-cluster. Therefore, the flag should be optional to enable this use case.

xref https://github.com/platform-mesh/backlog/issues/113