### PR TITLE
Rework documentation to use kcp in kind

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,27 +41,32 @@ sequenceDiagram
 
 ## How to use this example
 
-1. Create a kind cluster and install the MongoDB Operator
+1. Run the script to create a kind cluster and deploy kcp and cert-manager
 
     ```sh
-    export KUBECONFIG=cluster.kubeconfig
-    kind create cluster --name mongodb
+    ./hack/run-kcp-in-kind.sh
+    ```
+
+2. Deploy the MongoDB Operator in kind cluster
+
+    ```sh
+    export KUBECONFIG="./kind.kubeconfig"
     helm repo add mongodb https://mongodb.github.io/helm-charts
     helm repo update
-    helm upgrade mongodb mongodb/community-operator --version 0.13.0 --install --namespace mongodb --create-namespace
+    helm upgrade \
+        --install \
+        --wait \
+        --namespace mongodb \
+        --create-namespace \
+        --version 0.13.0 \
+        mongodb mongodb/community-operator
     kubectl apply -f sample/mongo-secret.yaml
     ```
 
-2. Start kcp locally
+3. Create the `consumer` and `mongodb` workspaces in kcp
 
     ```sh
-    kcp start --bind-address=127.0.0.1
-    ```
-
-3. Create the consumer and mongodb workspace
-
-    ```sh
-    export KUBECONFIG=".kcp/admin.kubeconfig"
+    export KUBECONFIG="./kcp-admin.kubeconfig"
     kubectl create workspace consumer
     kubectl create workspace mongodb
     ```
@@ -80,21 +85,34 @@ sequenceDiagram
 
     ```sh
     kubectl ws :root:mongodb
-    kubectl config view --minify --flatten > kcp.kubeconfig
+    kubectl config view --minify --flatten > kcp-controller.kubeconfig
     # set the server to the VirtualWorkspace url
-    kubectl --kubeconfig=kcp.kubeconfig config set-cluster "workspace.kcp.io/current" --server $(kubectl get apiexportendpointslices.apis.kcp.io mongodb -o jsonpath='{.status.endpoints[0].url}')
+    VW_URL="$(kubectl get apiexportendpointslices.apis.kcp.io mongodb -o jsonpath='{.status.endpoints[0].url}')"
+    # In the kind setup kcp uses a short service name (kcp:<port>); rewrite it
+    # to include the namespace (kcp.kcp:<port>) so the controller running in
+    # a different namespace can reach it.
+    VW_URL="${VW_URL//kcp:/kcp.kcp:}"
+    kubectl --kubeconfig=kcp-controller.kubeconfig config set-cluster --insecure-skip-tls-verify=true "workspace.kcp.io/current" --server "${VW_URL}"
     ```
 
-6. Start the controller
+6. Switch back to the kind cluster and create a Secret with kubeconfig, then
+   deploy the controller
 
     ```sh
-    go run main.go --kcp-kubeconfig=kcp.kubeconfig --target-kubeconfig=cluster.kubeconfig
+    export KUBECONFIG="./kind.kubeconfig"
+    kubectl create secret generic --namespace="mongodb" kcp-kubeconfig --from-file=kubeconfig=kcp-controller.kubeconfig
+    kubectl apply -f sample/deployment.yaml
     ```
 
-7. Create a MongoDB in the consumer workspace
+    > [!NOTE]
+    > If you're using this sample Deployment in some other setup, remove `hostAliases` from the manifest.
+    > The provided `hostAliases` is used to allow controller to connect to kcp in our kind setup where
+    > `kcp.dev.test` is not a valid domain.
+
+7. Switch back to kcp and create a MongoDB in the `consumer` workspace
 
     ```sh
-    export KUBECONFIG=".kcp/admin.kubeconfig"
+    export KUBECONFIG="./kcp-admin.kubeconfig"
     kubectl ws :root:consumer
     kubectl apply -f sample/mongodb.yaml
     ```
@@ -102,9 +120,8 @@ sequenceDiagram
     The syncer will sync the mongodb from kcp into the kubernetes cluster. After around a minute you should see in your Kubernetes cluster that the PHASE and VERSION field of your cluster are filled. The syncer will then sync this status into kcp. In the end, you should see the following in your kcp consumer workspace:
 
     ```sh
-    $ export KUBECONFIG=.kcp/admin.kubeconfig
-    $ k ws :root:consumer
-    $ k -n mongodb get mongodbcommunity.mongodbcommunity.mongodb.com example-mongodb
+    kubectl ws :root:consumer
+    kubectl -n mongodb get mongodbcommunity.mongodbcommunity.mongodb.com example-mongodb
     NAME              PHASE     VERSION
     example-mongodb   Running   6.0.5
     ```
@@ -112,7 +129,6 @@ sequenceDiagram
 8. Delete the object again
 
     ```sh
-    export KUBECONFIG=".kcp/admin.kubeconfig"
     kubectl ws :root:consumer
     kubectl delete -f sample/mongodb.yaml
     ```

--- a/hack/kind-kcp/kcp-values.yaml
+++ b/hack/kind-kcp/kcp-values.yaml
@@ -1,0 +1,26 @@
+externalHostname: "kcp.dev.test"
+externalPort: "8443"
+etcd:
+  resources:
+    requests:
+      memory: 256Mi
+certificates:
+  dnsNames:
+    - localhost
+    - kcp.dev.test
+kcp:
+  # tag is set via --set flag to make it more dynamic for testing purposes
+  volumeClassName: "standard"
+  tokenAuth:
+    enabled: true
+  hostAliases:
+    enabled: true
+    values:
+      - ip: "10.96.0.100"
+        hostnames:
+          - "kcp.dev.test"
+kcpFrontProxy:
+  service:
+    type: NodePort
+    nodePort: 31443
+    clusterIP: "10.96.0.100"

--- a/hack/kind-kcp/kind-config.yaml
+++ b/hack/kind-kcp/kind-config.yaml
@@ -1,0 +1,8 @@
+apiVersion: kind.x-k8s.io/v1alpha4
+kind: Cluster
+nodes:
+  - role: control-plane
+    extraPortMappings:
+      - containerPort: 31443
+        hostPort: 8443
+        protocol: TCP

--- a/hack/run-kcp-in-kind.sh
+++ b/hack/run-kcp-in-kind.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+echodate() {
+  # do not use -Is to keep this compatible with macOS
+  echo "[$(date +%Y-%m-%dT%H:%M:%S%:z)]" "$@"
+}
+
+kind="${KIND:-kind}"
+
+KCP_CHART_VERSION="${KCP_CHART_VERSION:-0.16.0}"
+CERT_MANAGER_VERSION="${CERT_MANAGER_VERSION:-v1.20.2}"
+
+CLUSTER_NAME="${CLUSTER_NAME:-kcp}"
+KIND_KUBECONFIG="${KIND_KUBECONFIG:-kind.kubeconfig}"
+KCP_ADMIN_KUBECONFIG="${KCP_ADMIN_KUBECONFIG:-kcp-admin.kubeconfig}"
+KCP_CONTROLLER_KUBECONFIG="${KCP_CONTROLLER_KUBECONFIG:-kcp-controller.kubeconfig}"
+kcp_hostname="${KCP_HOSTNAME:-kcp.dev.test}"
+
+# Whether the script should update /etc/hosts automatically. Set to "true" to allow
+# the script to append an entry; default is "false".
+UPDATE_HOSTS="${UPDATE_HOSTS:-false}"
+
+if ! command -v "$kind" >/dev/null 2>&1; then
+  echodate "❌ $kind is not installed or not in PATH" >&2
+  echodate $'\tInstall kind: https://kind.sigs.k8s.io/\n\tOr set the KIND environment variable to the path to the kind binary.' >&2
+  exit 1
+fi
+
+echodate "🔍 Checking for kind cluster '${CLUSTER_NAME}'..."
+if ! $kind get clusters | grep -w -q "$CLUSTER_NAME"; then
+  echodate "⚙️ Creating kind cluster '${CLUSTER_NAME}'..."
+  $kind create cluster \
+    --name "$CLUSTER_NAME" \
+    --config hack/kind-kcp/kind-config.yaml
+  echodate "✅ Created kind cluster '${CLUSTER_NAME}'."
+else
+  echodate "✅ Cluster $CLUSTER_NAME already exists."
+fi
+
+$kind get kubeconfig --name "$CLUSTER_NAME" > "$KIND_KUBECONFIG"
+
+echodate "📥 Adding helm repositories: jetstack, kcp"
+helm repo add jetstack https://charts.jetstack.io
+helm repo add kcp https://kcp-dev.github.io/helm-charts
+helm repo update
+
+echodate "⬇️ Installing cert-manager…"
+
+kubectl apply -f "https://github.com/cert-manager/cert-manager/releases/download/${CERT_MANAGER_VERSION}/cert-manager.crds.yaml"
+helm upgrade \
+  --install \
+  --wait \
+  --namespace cert-manager \
+  --create-namespace \
+  --version "${CERT_MANAGER_VERSION}" \
+  cert-manager jetstack/cert-manager
+
+# Installing cert-manager will end with a message saying that the next step
+# is to create some Issuers and/or ClusterIssuers.  That is indeed
+# among the things that the kcp helm chart will do.
+
+echodate "⚙️ Installing kcp…"
+
+helm upgrade \
+  --install \
+  --wait \
+  --values hack/kind-kcp/kcp-values.yaml \
+  --namespace kcp \
+  --create-namespace \
+  --version "${KCP_CHART_VERSION}" \
+  kcp kcp/kcp
+
+echodate "🔐 Generating KCP admin kubeconfig…"
+cat << EOF > "${KCP_ADMIN_KUBECONFIG}"
+apiVersion: v1
+kind: Config
+clusters:
+  - cluster:
+      insecure-skip-tls-verify: true
+      server: "https://${kcp_hostname}:8443/clusters/root"
+    name: kind-kcp
+contexts:
+  - context:
+      cluster: kind-kcp
+      user: kind-kcp
+    name: kind-kcp
+current-context: kind-kcp
+users:
+  - name: kind-kcp
+    user:
+      token: admin-token
+EOF
+
+echodate "🔍 Checking /etc/hosts for ${kcp_hostname}…"
+if ! grep -q "$kcp_hostname" /etc/hosts; then
+  update_hosts_lc="$(printf '%s' "$UPDATE_HOSTS" | tr '[:upper:]' '[:lower:]')"
+  if [ "$update_hosts_lc" = "true" ]; then
+    echo "127.0.0.1 $kcp_hostname" | sudo tee -a /etc/hosts
+    echodate "✅ Added ${kcp_hostname} to /etc/hosts."
+  else
+    echodate "⚠️ ${kcp_hostname} not found in /etc/hosts and UPDATE_HOSTS is false."
+    echodate "$(printf '\tTo add it manually, run as root:\n\t  sudo sh -c "echo \"127.0.0.1 %s\" >> /etc/hosts"\n' "$kcp_hostname")"
+    echodate "$(printf '\tOr add this line to /etc/hosts:\n\t  127.0.0.1 %s\n' "$kcp_hostname")"
+  fi
+else
+  echodate "✅ ${kcp_hostname} already exists in /etc/hosts."
+fi

--- a/sample/deployment.yaml
+++ b/sample/deployment.yaml
@@ -1,0 +1,80 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: example-mongodb-mcr-controller
+  namespace: mongodb
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: example-mongodb-mcr-controller-role
+rules:
+  - apiGroups: ["mongodbcommunity.mongodb.com"]
+    resources: ["mongodbcommunity"]
+    verbs: ["*"]
+  - apiGroups: ["mongodbcommunity.mongodb.com"]
+    resources: ["mongodbcommunity/status"]
+    verbs: ["*"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: example-mongodb-mcr-controller-binding
+  namespace: mongodb
+subjects:
+  - kind: ServiceAccount
+    name: example-mongodb-mcr-controller
+    namespace: mongodb
+roleRef:
+  kind: ClusterRole
+  name: example-mongodb-mcr-controller-role
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: example-mongodb-mcr-controller
+  namespace: mongodb
+  labels:
+    app: example-mongodb-mcr-controller
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: example-mongodb-mcr-controller
+  template:
+    metadata:
+      labels:
+        app: example-mongodb-mcr-controller
+    spec:
+      hostAliases:
+        - hostnames:
+            - kcp.dev.test
+          ip: 10.96.0.100
+      serviceAccountName: example-mongodb-mcr-controller
+      imagePullSecrets:
+        - name: ghcr-login-secret
+      containers:
+        - name: example-mongodb-mcr-controller
+          image: ghcr.io/platform-mesh/example-mongodb-multiclusterruntime:latest
+          imagePullPolicy: IfNotPresent
+          args:
+            - "--kcp-kubeconfig=/etc/kcp/kubeconfig"
+          volumeMounts:
+            - name: kcp-kubeconfig
+              mountPath: /etc/kcp
+              readOnly: true
+          resources:
+            limits:
+              cpu: "200m"
+              memory: "256Mi"
+            requests:
+              cpu: "50m"
+              memory: "64Mi"
+      volumes:
+        - name: kcp-kubeconfig
+          secret:
+            secretName: kcp-kubeconfig
+            items:
+              - key: kubeconfig
+                path: kubeconfig


### PR DESCRIPTION
Fixes https://github.com/platform-mesh/backlog/issues/113

The script is based on https://github.com/kcp-dev/helm-charts/blob/5bb3b1d025e8cae6f9d974712e56d518718a9957/hack/kind-setup.sh but modified to better suit our use case and to make it more user friendly.

The documentation is updated to use kcp in kind setup, as controller running in a kind cluster can't (easily) communicate with a kcp instance running locally (outside the cluster).

The provided sample Deployment is generally universal, but has `hostAliases` which works only in this setup. Users who want to use this Deployment in other setups should manually remove `hostAliases`. There's a note about this in README.