### PR TITLE
chore: standardize repository files

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,8 +129,4 @@ If you find any bug that may be a security problem, please follow our instructio
 
 ## Code of Conduct
 
-We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone. By participating in this project, you agree to abide by its [Code of Conduct](https://github.com/platform-mesh/.github/blob/main/CODE_OF_CONDUCT.md) at all times.
-
-## Licensing
-
-Copyright (20xx-)20xx SAP SE or an SAP affiliate company and example-mongodb-multiclusterruntime contributors. Please see our [LICENSE](LICENSE) for copyright and license information. Detailed information including third-party components and their licensing/copyright information is available [via the REUSE tool](https://api.reuse.software/info/github.com/platform-mesh/example-mongodb-multiclusterruntime).
+Please refer to our [Code of Conduct](https://github.com/platform-mesh/.github/blob/main/CODE_OF_CONDUCT.md) for information on the expected conduct for contributing to Platform Mesh.


### PR DESCRIPTION
## Summary

- Removed `## Licensing` section (SAP SE copyright) from README
- Standardized Code of Conduct section to reference [central .github repository](https://github.com/platform-mesh/.github/blob/main/CODE_OF_CONDUCT.md)

## Context

Repository governance files are being centralized in [platform-mesh/.github](https://github.com/platform-mesh/.github).